### PR TITLE
Fix blocto sdk dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fewcha/web3": "0.1.32",
-    "@blocto/sdk": "0.3.0-beta.9",
+    "@blocto/sdk": "0.3.1",
     "@keystonehq/aptossnap-adapter": "0.2.7",
     "@types/jest": "27.5.1",
     "@types/node": "18.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pontem/aptos-wallet-adapter",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Wallet adapter with supporting Vue and React",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.19.3.tgz"
   integrity sha512-pJ9xOlNWHiy9+FuFP09DEAFbAn4JskgRsVcc169w2xRBC3FRGuQEwjeIMMND9L2zc0iEhO/tGv4Zq+km+hxNpQ==
 
-"@blocto/sdk@0.3.0-beta.9":
-  version "0.3.0-beta.9"
-  resolved "https://registry.yarnpkg.com/@blocto/sdk/-/sdk-0.3.0-beta.9.tgz#87c74d36252afcabb64322c131b2eff3ee50bcf6"
-  integrity sha512-B+7s/oYdS+TWhDkEc/06nmS+4T0VsVy5T2V3yOUxS2iPuqdNcwRNJtC40JzB+OmrxJrST6zOE8VbW9ved95VOg==
+"@blocto/sdk@0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@blocto/sdk/-/sdk-0.3.1.tgz#ce27164a322b7aebe0634055a7c4dcc8920513de"
+  integrity sha512-vYZTq9QAgJyUQ15BljGhwVZzbrGLl1pEebRcLkoi7/UTyCsaU5p+oeVxyv1crCd8mARgbIcJGONdpOXLfpolaA==
   dependencies:
     bs58 "^4.0.1"
     buffer "^6.0.3"


### PR DESCRIPTION
* blockto sdk had peerDependency of @solana/web3.js
On next update with their sdk version they fixed this issue with peerDependencyMeta options

<img width="295" alt="Screenshot 2022-11-18 at 11 48 56" src="https://user-images.githubusercontent.com/25219331/202660589-dc390622-dc19-4072-a2d0-2394a01712d1.png">
